### PR TITLE
SCSt: Add Custom Client Info Provider

### DIFF
--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/pom.xml
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/pom.xml
@@ -17,6 +17,11 @@
     <description>A Spring Cloud Stream Binder implementation using the Solace Java API (JCSMP)</description>
     <url>https://github.com/${repoName}/solace-spring-cloud/tree/${project.scm.tag}/solace-spring-cloud-stream-binder</url>
 
+    <properties>
+        <build.timestamp>${maven.build.timestamp}</build.timestamp>
+        <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.solace.spring.cloud</groupId>
@@ -87,4 +92,41 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>templating-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <id>generate-templated-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>filter-sources</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>add-generated-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${basedir}/target/generated-sources/java-templates</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java-templates/com/solace/spring/cloud/stream/binder/config/SolaceBinderClientInfoProvider.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java-templates/com/solace/spring/cloud/stream/binder/config/SolaceBinderClientInfoProvider.java
@@ -1,0 +1,17 @@
+package com.solace.spring.cloud.stream.binder.config;
+
+import com.solacesystems.jcsmp.impl.client.ClientInfoProvider;
+
+class SolaceBinderClientInfoProvider extends ClientInfoProvider {
+	public String getSoftwareVersion() {
+		return String.format("@project.version@ (%s)", super.getSoftwareVersion());
+	}
+
+	public String getSoftwareDate() {
+		return String.format("@build.timestamp@ (%s)", super.getSoftwareDate());
+	}
+
+	public String getPlatform() {
+		return this.getPlatform("@project.name@ (JCSMP SDK)");
+	}
+}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/config/SolaceMessageChannelBinderConfiguration.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/main/java/com/solace/spring/cloud/stream/binder/config/SolaceMessageChannelBinderConfiguration.java
@@ -1,15 +1,16 @@
 package com.solace.spring.cloud.stream.binder.config;
 
+import com.solace.spring.cloud.stream.binder.SolaceMessageChannelBinder;
+import com.solace.spring.cloud.stream.binder.properties.SolaceExtendedBindingProperties;
+import com.solace.spring.cloud.stream.binder.provisioning.SolaceQueueProvisioner;
 import com.solacesystems.jcsmp.JCSMPException;
+import com.solacesystems.jcsmp.JCSMPFactory;
+import com.solacesystems.jcsmp.JCSMPProperties;
 import com.solacesystems.jcsmp.JCSMPSession;
-import com.solacesystems.jcsmp.SpringJCSMPFactory;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import com.solace.spring.cloud.stream.binder.SolaceMessageChannelBinder;
-import com.solace.spring.cloud.stream.binder.properties.SolaceExtendedBindingProperties;
-import com.solace.spring.cloud.stream.binder.provisioning.SolaceQueueProvisioner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -19,7 +20,7 @@ import javax.annotation.PostConstruct;
 @EnableConfigurationProperties({ SolaceExtendedBindingProperties.class })
 public class SolaceMessageChannelBinderConfiguration {
 	@Autowired
-	private SpringJCSMPFactory springJCSMPFactory;
+	private JCSMPProperties jcsmpProperties;
 
 	@Autowired
 	private SolaceExtendedBindingProperties solaceExtendedBindingProperties;
@@ -30,7 +31,9 @@ public class SolaceMessageChannelBinderConfiguration {
 
 	@PostConstruct
 	private void initSession() throws JCSMPException {
-		jcsmpSession = springJCSMPFactory.createSession();
+		JCSMPProperties jcsmpProperties = (JCSMPProperties) this.jcsmpProperties.clone();
+		jcsmpProperties.setProperty(JCSMPProperties.CLIENT_INFO_PROVIDER, new SolaceBinderClientInfoProvider());
+		jcsmpSession = JCSMPFactory.onlyInstance().createSession(jcsmpProperties);
 		logger.info(String.format("Connecting JCSMP session %s", jcsmpSession.getSessionName()));
 		jcsmpSession.connect();
 	}

--- a/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderConfigTest.java
+++ b/solace-spring-cloud-stream-binder/solace-spring-cloud-stream-binder/src/test/java/com/solace/spring/cloud/stream/binder/SolaceBinderConfigTest.java
@@ -1,0 +1,63 @@
+package com.solace.spring.cloud.stream.binder;
+
+import com.solace.spring.cloud.stream.binder.config.SolaceServiceAutoConfiguration;
+import com.solace.spring.cloud.stream.binder.test.util.IgnoreInheritedTests;
+import com.solace.spring.cloud.stream.binder.test.util.InheritedTestsFilteredSpringRunner;
+import com.solace.test.integration.semp.v2.monitor.model.MonitorMsgVpnClient;
+import com.solacesystems.jcsmp.JCSMPProperties;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+/**
+ * Binder {@link Configuration @Configuration} testing.
+ *
+ * These are <b>NOT</b> tests regarding {@link SolaceMessageChannelBinder}.
+ */
+@RunWith(InheritedTestsFilteredSpringRunner.class)
+@ContextConfiguration(classes = {SolaceServiceAutoConfiguration.class},
+		initializers = {ConfigFileApplicationContextInitializer.class, SolaceBinderConfigTest.Initializer.class})
+@IgnoreInheritedTests
+public class SolaceBinderConfigTest extends SolaceBinderTestBase {
+	@Autowired
+	private JCSMPProperties jcsmpProperties;
+
+	@Test
+	public void testClientInfoProvider() throws Exception {
+		String vpnName = jcsmpProperties.getStringProperty(JCSMPProperties.VPN_NAME);
+		String clientName = jcsmpProperties.getStringProperty(JCSMPProperties.CLIENT_NAME);
+		MonitorMsgVpnClient client = sempV2Api.monitor()
+				.getMsgVpnClient(vpnName, clientName, null)
+				.getData();
+
+		Pattern versionPattern = Pattern.compile("[0-9]+\\.[0-9]+\\.[0-9]+");
+		Pattern datePattern = Pattern.compile("[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}");
+
+		SoftAssertions softly = new SoftAssertions();
+		softly.assertThat(client.getSoftwareVersion())
+				.matches(String.format("%s(?:-SNAPSHOT)? \\(%s\\)", versionPattern, versionPattern));
+		softly.assertThat(client.getSoftwareDate()).matches(String.format("%s \\(%s\\)", datePattern, datePattern));
+		softly.assertThat(client.getPlatform()).contains("Solace Spring Cloud Stream Binder (JCSMP SDK)");
+		softly.assertAll();
+	}
+
+	static class Initializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+		@Override
+		public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
+			String clientName = SolaceBinderConfigTest.class.getName() + UUID.randomUUID().toString();
+			TestPropertyValues.of(
+						String.format("solace.java.apiProperties.%s=%s", JCSMPProperties.CLIENT_NAME, clientName))
+					.applyTo(configurableApplicationContext.getEnvironment());
+		}
+	}
+}


### PR DESCRIPTION
Add a custom client info provider to contain the metadata details about the binder so that broker operators can easily tell which clients are using this SCSt-binder.